### PR TITLE
[Clean]設定管理クラスの設定項目の名前空間化

### DIFF
--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -5,7 +5,9 @@
 
 #define OLED_I2C_INSTANCE Wire
 
-#define MAX_PEDALS 7
+#define PEDAL_COUNT 6
+#define EXP_PEDAL_COUNT 1
+#define MAX_PEDALS (PEDAL_COUNT + EXP_PEDAL_COUNT)
 
 #define EXP_CH 0
 

--- a/src/libs/PedalsController/PedalsController.cpp
+++ b/src/libs/PedalsController/PedalsController.cpp
@@ -44,9 +44,9 @@ void PedalsController::pedalsCallback(int index, bool state) {
     }else{
         if (index < 0 || index >= MAX_PEDALS-1) return;
 
-        if (settings_.getPedalSettings(index).pedalMode == SettingsManager::PedalMode::CC) {
+        if (settings_.getPedalSettings(index).pedalMode == PedalMode::CC) {
             // Control Change
-            if (settings_.getPedalSettings(index).switchBehavior == SettingsManager::SwitchBehavior::TOGGLE) {
+            if (settings_.getPedalSettings(index).switchBehavior == SwitchBehavior::TOGGLE) {
                 if (state) {
                     CCPedalState_[index] = !CCPedalState_[index];
                     usbMIDI_.sendControlChange(
@@ -56,7 +56,7 @@ void PedalsController::pedalsCallback(int index, bool state) {
                     );
                 }
                 return;
-            }else if(settings_.getPedalSettings(index).switchBehavior == SettingsManager::SwitchBehavior::MOMENTARY){
+            }else if(settings_.getPedalSettings(index).switchBehavior == SwitchBehavior::MOMENTARY){
                 // モーメンタリ動作の場合、そのまま送信
                 usbMIDI_.sendControlChange(
                     settings_.getPedalSettings(index).midiChannel,
@@ -64,7 +64,7 @@ void PedalsController::pedalsCallback(int index, bool state) {
                     state ? 127 : 0
                 );
             }
-        }else if(settings_.getPedalSettings(index).pedalMode == SettingsManager::PedalMode::PC_NEXT){
+        }else if(settings_.getPedalSettings(index).pedalMode == PedalMode::PC_NEXT){
             // Program Change Next
             if(state){
                 PCCurrentNumber_++;
@@ -74,7 +74,7 @@ void PedalsController::pedalsCallback(int index, bool state) {
                     PCCurrentNumber_
                 );
             }
-        }else if(settings_.getPedalSettings(index).pedalMode == SettingsManager::PedalMode::PC_BACK){
+        }else if(settings_.getPedalSettings(index).pedalMode == PedalMode::PC_BACK){
             // Program Change Back
             if(state){
                 if (PCCurrentNumber_ == 0) {

--- a/src/libs/PedalsController/PedalsController.hpp
+++ b/src/libs/PedalsController/PedalsController.hpp
@@ -7,8 +7,10 @@
 #include <HalUSBMIDI.hpp>
 #include <HalStorage.hpp>
 #include <SettingsManager/SettingsManager.hpp>
+#include <SettingsManager/SettingsDefs.hpp>
 #include <config.h>
 
+using namespace SettingsDefs;
 class PedalsController {
 public:
     PedalsController(HalPedal& pedals,
@@ -51,9 +53,9 @@ private:
 
     static PedalsController* self;
 
-    const int pedalPins_[MAX_PEDALS-1] = {PEDAL1_PIN, PEDAL2_PIN, PEDAL3_PIN, PEDAL4_PIN, PEDAL5_PIN, PEDAL6_PIN};
+    const int pedalPins_[PEDAL_COUNT] = {PEDAL1_PIN, PEDAL2_PIN, PEDAL3_PIN, PEDAL4_PIN, PEDAL5_PIN, PEDAL6_PIN};
 
-    bool CCPedalState_[MAX_PEDALS-1];
+    bool CCPedalState_[PEDAL_COUNT] = {false, false, false, false, false, false};
     uint8_t PCCurrentNumber_ = 0;
     
     bool midiStarted_ = false;

--- a/src/libs/SettingsManager/SettingsDefs.hpp
+++ b/src/libs/SettingsManager/SettingsDefs.hpp
@@ -1,0 +1,37 @@
+#ifndef SETTINGSDEFS_H
+#define SETTINGSDEFS_H
+#include <stdint.h>
+#include <config.h>
+
+namespace SettingsDefs{
+    // ==== ペダルの動作モード ====
+    enum class PedalMode : uint8_t {
+        NONE = 0,     // 
+        CC = 1,       // Send Control Change
+        PC_NEXT = 2,  // Program Change: next preset
+        PC_BACK = 3   // Program Change: previous preset
+    };
+
+    // ==== スイッチの判定モード ====
+    enum class SwitchBehavior : uint8_t {
+        MOMENTARY = 0, // 押してる間だけON
+        TOGGLE    = 1  // 押すたびにON/OFFが反転
+    };
+
+    // ==== 1つのペダルが持つ設定 ====
+    struct PedalSettings {
+        PedalMode pedalMode;        // 何を送るか (CC / PC_NEXT / PC_BACK)
+        uint8_t   midiChannel;      // 1-16
+        uint8_t   ccNumber;         // CC番号
+        SwitchBehavior switchBehavior; // モーメンタリ or トグル
+        uint8_t   _pad;             // アラインメント/将来拡張用
+    };
+
+    // ==== 全体設定 ====
+    struct Settings {
+        uint8_t version;                        // 互換性管理
+        PedalSettings pedal[MAX_PEDALS];        // ペダルごとの設定
+    };
+}
+
+#endif // SETTINGSDEFS_H

--- a/src/libs/SettingsManager/SettingsManager.cpp
+++ b/src/libs/SettingsManager/SettingsManager.cpp
@@ -25,12 +25,12 @@ bool SettingsManager::begin() {
     return true;
 }
 
-const SettingsManager::Settings& SettingsManager::getAllSettings() const {
+const Settings& SettingsManager::getAllSettings() const {
 LockGuard lock(mtx_);
 return ramSettings_;
 }
 
-const SettingsManager::PedalSettings& SettingsManager::getPedalSettings(size_t pedalIndex) const {
+const PedalSettings& SettingsManager::getPedalSettings(size_t pedalIndex) const {
     LockGuard lock(mtx_);
     return ramSettings_.pedal[pedalIndex];
 }
@@ -158,6 +158,18 @@ bool SettingsManager::commitSettings() {
     }
     return ok;
 }
+
+void SettingsManager::uncommitSettings() {
+    LockGuard lock(mtx_);
+    if (initialized_ == false || dirty_ == false) {
+        return;
+    }
+    if (!loadFromStorage()) {
+        loadFactoryDefaults();
+    } 
+    dirty_ = false;
+    return;
+}   
 
 //------------------
 // Private methods

--- a/src/libs/SettingsManager/SettingsManager.hpp
+++ b/src/libs/SettingsManager/SettingsManager.hpp
@@ -4,38 +4,11 @@
 #include <string.h>
 #include <HalStorage.hpp>
 #include <config.h>
+#include "SettingsDefs.hpp"
+
+using namespace SettingsDefs;
 
 class SettingsManager {
-public:
-    // ==== ペダルの動作モード ====
-    enum class PedalMode : uint8_t {
-        NONE = 0,     // 
-        CC = 1,       // Send Control Change
-        PC_NEXT = 2,  // Program Change: next preset
-        PC_BACK = 3   // Program Change: previous preset
-    };
-
-    // ==== スイッチの判定モード ====
-    enum class SwitchBehavior : uint8_t {
-        MOMENTARY = 0, // 押してる間だけON
-        TOGGLE    = 1  // 押すたびにON/OFFが反転
-    };
-
-    // ==== 1つのペダルが持つ設定 ====
-    struct PedalSettings {
-        PedalMode pedalMode;        // 何を送るか (CC / PC_NEXT / PC_BACK)
-        uint8_t   midiChannel;      // 1-16
-        uint8_t   ccNumber;         // CC番号
-        SwitchBehavior switchBehavior; // モーメンタリ or トグル
-        uint8_t   _pad;             // アラインメント/将来拡張用
-    };
-
-    // ==== 全体設定 ====
-    struct Settings {
-        uint8_t version;                        // 互換性管理
-        PedalSettings pedal[MAX_PEDALS];        // ペダルごとの設定
-    };
-
 public:
     explicit SettingsManager(HalStorage& storage)
     : storage_(storage)
@@ -114,9 +87,23 @@ public:
     bool commitSettings();
 
     /**
+     * @brief dirty_を強制的にfalseにする（EEPROM反映済み扱いにする）
+     */
+    void uncommitSettings();
+
+    /**
      * @brief デフォルト設定をRAM+EEPROMへ反映
      */
     void FactoryReset();
+
+    /**
+     * @brief 設定がEEPROMに反映されていないかどうか取得
+     * @return dirty_の値
+     */
+    bool getIsDirty() const {
+        LockGuard lock(mtx_);
+        return dirty_;
+    }
 
 private:
     SettingsManager() = default;


### PR DESCRIPTION
- Settings,PedalSettings, SwitchBehavior, PedalModeを名前空間SettingsDefsに移動
- ioメソッドの追加