### PR TITLE
［Update］ メニュー描画クラスをコンストラクタでパラーメーターを渡すように修正

### DIFF
--- a/lib/DrawDisplay/src/DrawDisplay.cpp
+++ b/lib/DrawDisplay/src/DrawDisplay.cpp
@@ -1,16 +1,16 @@
 #include "DrawDisplay.hpp"
 
-DrawDisplay::DrawDisplay(){}
-
-void DrawDisplay::begin(TwoWire* wireInstance, int SDA_PIN, int SCL_PIN, int width, int height, int address){
+DrawDisplay::DrawDisplay(TwoWire* wireInstance, int SDA_PIN, int SCL_PIN, int width, int height, int address=DEFAULT_SCREEN_ADDRESS)
+: ADDRESS(address), screenWidth(width), screenHeight(height) {
 	wire = wireInstance;
-    wire->setSDA(SDA_PIN);
-    wire->setSCL(SCL_PIN);
-	screenWidth = width;
-	screenHeight = height;
+	wire->setSDA(SDA_PIN);
+	wire->setSCL(SCL_PIN);
+}
+
+void DrawDisplay::begin(){
 	display = new Adafruit_SSD1306(screenWidth, screenHeight, wire, OLED_RESET);
 
-	if(!display->begin(SSD1306_SWITCHCAPVCC, address)) {
+	if(!display->begin(SSD1306_SWITCHCAPVCC, ADDRESS)) {
 		for(;;); // Don't proceed, loop forever
 	}
 

--- a/lib/DrawDisplay/src/DrawDisplay.hpp
+++ b/lib/DrawDisplay/src/DrawDisplay.hpp
@@ -19,9 +19,10 @@
 #define FONT_HEIGHT 6
 class DrawDisplay: public HalDisplay {
 public:
-    DrawDisplay();
+    DrawDisplay(TwoWire* wireInstance, int SDA_PIN, int SCL_PIN, int width, int height, int address=DEFAULT_SCREEN_ADDRESS);
+    ~DrawDisplay(){ delete display; }
 
-    void begin(TwoWire* wireInstance, int SDA, int SCL, int screenWidth, int screenHeight, int screenAddress=DEFAULT_SCREEN_ADDRESS) override;
+    void begin() override;
     void clearDisplay() override;
     void drawCentreString(const String &buf) override;
     void drawCentreNumber(const int Number) override;

--- a/lib/Hal/HalDisplay.hpp
+++ b/lib/Hal/HalDisplay.hpp
@@ -11,12 +11,7 @@ public:
     virtual ~HalDisplay() {}
 
     // OLED等の初期化処理
-    virtual void begin(TwoWire* wireInstance,
-                       int SDA,
-                       int SCL,
-                       int screenWidth,
-                       int screenHeight,
-                       int screenAddress = DEFAULT_ADC_ADDRESS) = 0;
+    virtual void begin() = 0;
 
     // 画面全体をクリア
     virtual void clearDisplay() = 0;

--- a/src/libs/MenuDisplay/MenuDisplay.cpp
+++ b/src/libs/MenuDisplay/MenuDisplay.cpp
@@ -1,4 +1,9 @@
 #include "MenuDisplay.hpp"
+
+void MenuDisplay::begin() {
+    display_.begin();
+}
+
 void MenuDisplay::render(int cursorIndex, bool selected, MenuConfig currentMenu) {
 
     if( currentMenu.itemCount <= cursorIndex ) {

--- a/src/libs/MenuDisplay/MenuDisplay.hpp
+++ b/src/libs/MenuDisplay/MenuDisplay.hpp
@@ -12,13 +12,7 @@ public:
     MenuDisplay(HalDisplay& display)
         : display_(display){}
     
-    void begin(TwoWire* wireInstance,
-               int SDA,
-               int SCL,
-               int screenWidth,
-               int screenHeight) {
-        display_.begin(wireInstance, SDA, SCL, screenWidth, screenHeight);
-    }
+    void begin();
 
     void render(int cursorIndesx, bool selected, MenuConfig currentMenu);
 private:

--- a/src/libs/MenuManager/MenuManager.cpp
+++ b/src/libs/MenuManager/MenuManager.cpp
@@ -1,9 +1,10 @@
 #include "MenuManager.hpp"
-void MenuManager::init(MenuConfig& initMenu, TwoWire* wireInstance, int SDA, int SCL, int screenWidth, int screenHeight) {
-    menuDisplay_.begin(wireInstance, SDA, SCL, screenWidth, screenHeight);
-    currentMenu = initMenu;
+void MenuManager::init(MenuID initMenuID) {
+    menuDisplay_.begin();
+    currentMenu = *getMenuConfig(initMenuID);
     selected = false;
     param = 0;
+    index = 0;
 }
 
 MenuConfig MenuManager::getCurrentMenu() const {

--- a/src/libs/MenuManager/MenuManager.hpp
+++ b/src/libs/MenuManager/MenuManager.hpp
@@ -22,7 +22,7 @@ public:
      * @brief メニューシステムを初期化する
      * @param initMenu 初期メニュー設定
     */
-    void init(MenuConfig& initMenu, TwoWire* wireInstance, int SDA, int SCL, int screenWidth, int screenHeight);
+    void init(MenuID initMenuID);
     
     /**
      * @brief 現在のメニュー設定を取得する


### PR DESCRIPTION
- MenuMangerの初期化時はパラーメーターIDで起動画面を指定するように変更