### PR TITLE
docs: ハードウェア配置説明を修正 #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ DAW ソフトやアンプシミュレーター（Amplitube / Helix Native など
 - **ADC IC** MCP3421
 - **その他:** 6.35mm ジャック、TRS、PCB（KiCad）、3Dプリントケース
 
-PCB と 3D モデルは `/hardware/pcb/` と `/hardware/3d/` に配置しています。
+KiCad の設計データとガーバーファイルは `hardware/MIDI_Pedal/`、3D モデルは `3d-models/` に配置しています。
 
 
 ## Software


### PR DESCRIPTION
## 概要

README に記載されていたハードウェア関連ファイルの配置説明を、現在のディレクトリ構成に合わせて修正しました。

## スコープ

- README の `Hardware` セクションにある配置説明を修正
- KiCad の設計データとガーバーファイルの場所を `hardware/MIDI_Pedal/` として記載
- 3D モデルの場所を `3d-models/` として記載

## Issue

Closes #40

## 確認内容

- 実際のディレクトリとして `hardware/MIDI_Pedal/` が存在することを確認
- 実際のディレクトリとして `3d-models/` が存在することを確認
- README の説明が実配置と一致していることを確認

## 補足

ドキュメントのみの変更のため、ビルドとテストは実行していません。