### PR TITLE
chore: PlatformIOビルドCIを追加 #55

### DIFF
--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -1,0 +1,34 @@
+name: PlatformIO Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - pico
+          - pico-debug
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PlatformIO Core
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+
+      - name: Build (${{ matrix.env }})
+        run: pio run -e ${{ matrix.env }}

--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -31,4 +31,6 @@ jobs:
           pip install platformio
 
       - name: Build (${{ matrix.env }})
+        env:
+          PLATFORMIO_BUILD_FLAGS: -I include -I lib/config
         run: pio run -e ${{ matrix.env }}


### PR DESCRIPTION
## 概要
PlatformIO のビルド確認を GitHub Actions で自動実行する CI を追加しました。

## スコープ
- `.github/workflows/platformio-build.yml` を追加
- `pull_request` と `develop` への `push` をトリガーに設定
- `pico` / `pico-debug` を matrix でビルド
- Python 3.12 + PlatformIO Core をセットアップして `pio run` を実行

## Issue
Closes #55

## 確認内容
- ワークフローファイルの構文とトリガー条件を確認
- `pico` / `pico-debug` が両方ジョブ対象になることを確認

## 補足
ローカルでは Actions 実行環境を再現していないため、実際のビルド確認は PR の Actions 実行結果で確認します。
