### PR TITLE
chore: PlatformIOキャッシュ戦略を追加 #56

### DIFF
--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -30,6 +30,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install platformio
 
+      - name: Cache PlatformIO Packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.platformio/packages
+          key: ${{ runner.os }}-platformio-${{ hashFiles('platformio.ini', '.github/workflows/platformio-build.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-platformio-
+
       - name: Build (${{ matrix.env }})
         env:
           PLATFORMIO_BUILD_FLAGS: -I include -I lib/config


### PR DESCRIPTION
## 概要
PlatformIO ビルド CI の実行時間を短縮するため、パッケージキャッシュ戦略を追加しました。

## スコープ
- `.github/workflows/platformio-build.yml` に `actions/cache@v4` を追加
- キャッシュ対象:
  - `~/.platformio/.cache`
  - `~/.platformio/packages`
- キャッシュキー:
  - `${{ runner.os }}`
  - `platformio.ini` のハッシュ
  - ワークフローファイルのハッシュ
- `restore-keys` に OS 単位のフォールバックを設定

## Issue
Closes #56

## 確認内容
- キャッシュキーに Issue 要件どおりの要素（OS / `platformio.ini` / workflow）が含まれることを確認
- キャッシュ対象ディレクトリが PlatformIO パッケージ取得に影響する範囲をカバーしていることを確認

## 補足
キャッシュ有効時の速度改善は、PR の Actions 実行履歴（初回と2回目以降）で確認します。
