### PR TITLE
docs: READMEにCI運用情報を追加 #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ KiCad の設計データは `hardware/kicad/`、PDF やガーバーファイル�
 - **スイッチ管理:** デバウンス、ラッチ/モーメンタリ対応  
 - **表示:** Adafruit SSD1306@^2.5.15
 
+## CI
+
+[![PlatformIO Build](https://github.com/starkensan/Pi_Pedal/actions/workflows/platformio-build.yml/badge.svg?branch=develop)](https://github.com/starkensan/Pi_Pedal/actions/workflows/platformio-build.yml)
+
+GitHub Actions で PlatformIO ビルドを自動実行しています。
+
+- ワークフロー: `PlatformIO Build`
+- 対象: `pull_request`, `develop` への `push`
+- ビルド対象: `pico`, `pico-debug`
+
+PR レビュー時は、`PlatformIO Build` が成功していることを確認してください。
+
 
 ## Build & Upload (CUI / PlatformIO CLI)
 


### PR DESCRIPTION
## 概要
README に CI の確認先と運用観点を追加し、PR レビュー時のチェックポイントを明文化しました。

## スコープ
- README に `CI` セクションを追加
- `PlatformIO Build` ワークフローへのリンクを追加
- `develop` ブランチのステータスバッジを追加
- PR 時に `PlatformIO Build` の成功確認が必要であることを明記

## Issue
Closes #57

## 確認内容
- README から Actions ワークフローへ直接遷移できることを確認
- バッジURLとワークフローURLが `platformio-build.yml` を指していることを確認
- PR レビュー観点として CI 成功が文章で記載されていることを確認
