### PR TITLE
chore: CIをソース変更時のみ実行 #62

### DIFF
--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -2,9 +2,23 @@ name: PlatformIO Build
 
 on:
   pull_request:
+    paths:
+      - "src/**"
+      - "lib/**"
+      - "include/**"
+      - "test/**"
+      - "platformio.ini"
+      - ".github/workflows/platformio-build.yml"
   push:
     branches:
       - develop
+    paths:
+      - "src/**"
+      - "lib/**"
+      - "include/**"
+      - "test/**"
+      - "platformio.ini"
+      - ".github/workflows/platformio-build.yml"
 
 jobs:
   build:


### PR DESCRIPTION
## 概要
PlatformIO ビルド CI を、ソースコード関連の変更時のみ実行するように変更しました。

## スコープ
- `.github/workflows/platformio-build.yml` の `pull_request` に `paths` 条件を追加
- `.github/workflows/platformio-build.yml` の `push`（`develop`）に `paths` 条件を追加
- CI 実行対象を以下に限定:
  - `src/**`
  - `lib/**`
  - `include/**`
  - `test/**`
  - `platformio.ini`
  - `.github/workflows/platformio-build.yml`

## Issue
Closes #62

## 確認内容
- ワークフロー定義で `paths` 条件が `pull_request` / `push` の両方に設定されていることを確認
- ドキュメントのみ変更時は CI 起動対象外になる設定であることを確認
