### PR TITLE
chore: PlatformIOビルドCI運用を補強 #58

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@
 
 ## 確認内容
 
+- [ ] `PlatformIO Build` が成功している
+- [ ] `pio run -e pico` が成功している
+- [ ] `pio run -e pico-debug` が成功している
 
 ## 補足
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,23 @@ docs: 開発ルールを追加 #38
 feat: MIDI チャンネル設定を追加 #42
 ```
 
+## Pull Request Checks
+
+Pull Request を作成したら、GitHub Actions の `PlatformIO Build` が成功していることを確認してください。
+
+- 対象 workflow: `.github/workflows/platformio-build.yml`
+- 実行タイミング: `pull_request`、および `develop` への `push`
+- ビルド対象: `pico`, `pico-debug`
+
+ローカルで事前確認する場合は、以下を実行してください。
+
+```bash
+pio run -e pico
+pio run -e pico-debug
+```
+
+PR では、ビルド成功を確認内容に記載してください。
+
 ## Source Layout
 
 モジュール配置は以下の方針で統一します。

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ board = waveshare_rp2040_zero
 framework = arduino
 build_flags = 
 	-I src/app
+	-I include
 	-D USE_TINYUSB
 	-D DEBUGLOG_DEFAULT_LOG_LEVEL_DEBUG
 	-D UNITY_INCLUDE_CONFIG_H
@@ -36,6 +37,7 @@ board = pico
 framework = arduino
 build_flags = 
 	-I src/app
+	-I include
 	-D USE_TINYUSB
 	-D DEBUGLOG_DEFAULT_LOG_LEVEL_INFO
 	-D UNITY_INCLUDE_CONFIG_H


### PR DESCRIPTION
## 概要
PlatformIO Build CI の完了条件を満たすため、ビルド設定と PR 運用ドキュメントを補強します。

## スコープ
- pico / pico-debug の build_flags に include パスを追加
- CONTRIBUTING に PlatformIO Build 確認ルールを追加
- PR テンプレートに CI / ローカルビルド確認項目を追加

## Issue
Closes #58

## 確認内容
- pio run -e pico
- pio run -e pico-debug

## 補足
初回確認時、Unity の unity_config.h が見つからずビルドが失敗しました。include パス追加後に両環境のビルド成功を確認しています。