### PR TITLE
test: nativeテスト環境を追加 #66

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ PR では、ビルド成功を確認内容に記載してください。
 - `test/ci/`: PC/native 環境で自動実行できるテスト
 
 新しい CI 向けテストを追加する場合は、実機依存を避け、`test/ci/test_<target>/` に配置してください。
+CI 向けテストは `pio test -e native` で実行します。
 詳細な分類ルールは `test/README` を参照してください。
 
 ## Source Layout

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,3 +54,17 @@ upload_protocol = cmsis-dap
 debug_tool = cmsis-dap
 debug_init_break = tbreak setup
 build_type = debug
+
+[env:native]
+platform = native
+test_build_src = no
+test_filter =
+	ci/*
+test_ignore =
+	manual/*
+build_flags =
+	-I include
+	-I src/app
+	-D UNITY_INCLUDE_CONFIG_H
+lib_deps =
+	throwtheswitch/Unity@^2.6.0

--- a/test/README
+++ b/test/README
@@ -8,7 +8,7 @@
 | Category | Path | Purpose | Execution |
 | --- | --- | --- | --- |
 | manual | `test/manual/` | RP2040 Zero、OLED、I2C、USB MIDI、ペダル、ロータリーエンコーダなどの実機確認 | 必要な実機を接続して手動実行 |
-| ci | `test/ci/` | PC/native 環境で安定実行できるユニットテスト | CI とローカルで自動実行 |
+| ci | `test/ci/` | PC/native 環境で安定実行できるユニットテスト | `pio test -e native` |
 
 ## Existing Test Suites
 
@@ -36,12 +36,20 @@
 ## CI Exclusion Policy
 
 CI/native テスト環境を追加するときは、`test/manual/**` を CI 実行対象から除外します。
-`platformio.ini` に native 環境を追加する場合は、以下の方針で設定します。
+`platformio.ini` の `env:native` は以下の方針で設定します。
 
 ```ini
 [env:native]
-test_filter = ci/*
-test_ignore = manual/*
+test_filter =
+	ci/*
+test_ignore =
+	manual/*
+```
+
+CI/PC 向けテストは以下で実行します。
+
+```bash
+pio test -e native
 ```
 
 manual テストを実行する場合は、対象スイートを明示して実行します。

--- a/test/ci/README
+++ b/test/ci/README
@@ -5,3 +5,9 @@
 現時点では CI 向けテストスイートは未追加です。新規に追加する場合は、`test/ci/test_<target>/test_main.cpp` の形式で作成します。
 
 CI に含めるテストは、実機接続、手動操作、USB/I2C/GPIO の実デバイスに依存しないものに限定します。
+
+CI/PC 向けテストは以下で実行します。
+
+```bash
+pio test -e native
+```


### PR DESCRIPTION
## 概要
CI/PC で実行する native テスト環境を PlatformIO に追加します。

## スコープ
- `platformio.ini` に `env:native` を追加
- native では `test/ci/*` のみを対象にし、`test/manual/*` を除外
- `pio test -e native` の実行方法を `test/README`、`test/ci/README`、`CONTRIBUTING.md` に追記

## Issue
Closes #66

## 確認内容
- `pio test -e native`
- `pio test -e native --list-tests`

## 補足
この PR は #76 を前提にした stacked PR です。既存テストは #76 で `test/manual/` へ分類済みで、native 環境では manual スイートが実行されない構成にしています。
