### PR TITLE
test: SettingsManagerをnativeテスト可能に分離 #65

### DIFF
--- a/lib/Hal/HalStorage.hpp
+++ b/lib/Hal/HalStorage.hpp
@@ -1,7 +1,7 @@
 #ifndef HAL_STORAGE_HPP
 #define HAL_STORAGE_HPP
 
-#include <Arduino.h>
+#include <stddef.h>
 
 /**
  * @brief EEPROM互換のストレージ操作を抽象化するインターフェイス

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,7 +57,10 @@ build_type = debug
 
 [env:native]
 platform = native
-test_build_src = no
+test_build_src = yes
+build_src_filter =
+	-<*>
+	+<app/SettingsManager/SettingsManager.cpp>
 test_filter =
 	ci/*
 test_ignore =
@@ -65,6 +68,9 @@ test_ignore =
 build_flags =
 	-I include
 	-I src/app
+	-I lib/Hal
+	-I test/Mocks
+	-D PIPEDAL_NATIVE_TEST
 	-D UNITY_INCLUDE_CONFIG_H
 lib_deps =
 	throwtheswitch/Unity@^2.6.0

--- a/src/app/SettingsManager/SettingsLock.hpp
+++ b/src/app/SettingsManager/SettingsLock.hpp
@@ -1,0 +1,33 @@
+#ifndef SETTINGSLOCK_HPP_
+#define SETTINGSLOCK_HPP_
+
+#ifdef PIPEDAL_NATIVE_TEST
+class SettingsLock {
+public:
+    void init() {}
+    void lock() {}
+    void unlock() {}
+};
+#else
+#include <pico/mutex.h>
+
+class SettingsLock {
+public:
+    void init() {
+        mutex_init(&mtx_);
+    }
+
+    void lock() {
+        mutex_enter_blocking(&mtx_);
+    }
+
+    void unlock() {
+        mutex_exit(&mtx_);
+    }
+
+private:
+    mutex_t mtx_;
+};
+#endif
+
+#endif // SETTINGSLOCK_HPP_

--- a/src/app/SettingsManager/SettingsManager.cpp
+++ b/src/app/SettingsManager/SettingsManager.cpp
@@ -5,7 +5,7 @@
 //----------------
 
 bool SettingsManager::begin() {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     
     if (initialized_) {
         return true;
@@ -26,17 +26,17 @@ bool SettingsManager::begin() {
 }
 
 const Settings& SettingsManager::getAllSettings() const {
-LockGuard lock(mtx_);
-return ramSettings_;
+    LockGuard lock(lock_);
+    return ramSettings_;
 }
 
 const PedalSettings& SettingsManager::getPedalSettings(size_t pedalIndex) const {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     return ramSettings_.pedal[pedalIndex];
 }
 
 void SettingsManager::setPedalMode(size_t pedalIndex, PedalMode mode) {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     if (pedalIndex >= MAX_PEDALS) return;
 
     if (ramSettings_.pedal[pedalIndex].pedalMode != mode) {
@@ -47,7 +47,7 @@ void SettingsManager::setPedalMode(size_t pedalIndex, PedalMode mode) {
 }
 
 void SettingsManager::setMidiChannel(size_t pedalIndex, uint8_t ch) {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     if (pedalIndex >= MAX_PEDALS) return;
     // 必要なら1〜16にクリップとかする
     if (ramSettings_.pedal[pedalIndex].midiChannel != ch) {
@@ -58,7 +58,7 @@ void SettingsManager::setMidiChannel(size_t pedalIndex, uint8_t ch) {
 }
 
 void SettingsManager::setCCNumber(size_t pedalIndex, uint8_t cc) {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     if (pedalIndex >= MAX_PEDALS) return;
 
     if (ramSettings_.pedal[pedalIndex].ccNumber != cc) {
@@ -69,7 +69,7 @@ void SettingsManager::setCCNumber(size_t pedalIndex, uint8_t cc) {
 }
 
 void SettingsManager::setSwitchBehavior(size_t pedalIndex, SwitchBehavior behavior) {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     if (pedalIndex >= MAX_PEDALS) return;
 
     if (ramSettings_.pedal[pedalIndex].switchBehavior != behavior) {
@@ -80,7 +80,7 @@ void SettingsManager::setSwitchBehavior(size_t pedalIndex, SwitchBehavior behavi
 }
 
 void SettingsManager::setPedalSettings(size_t pedalIndex, const PedalSettings& ps) {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     if (pedalIndex >= MAX_PEDALS) return;
 
     bool changed = false;
@@ -109,7 +109,7 @@ void SettingsManager::setPedalSettings(size_t pedalIndex, const PedalSettings& p
 }
 
 void SettingsManager::setAllSettings(const Settings& s) {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     bool changed = false;
 
     for (size_t i = 0; i < MAX_PEDALS; ++i) {
@@ -141,13 +141,13 @@ void SettingsManager::setAllSettings(const Settings& s) {
 }
 
 void SettingsManager::FactoryReset() {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     loadFactoryDefaults();
     return;
 }
 
 bool SettingsManager::commitSettings() {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     if (!dirty_) {
         return true; // 保存する変更なし
     }
@@ -160,7 +160,7 @@ bool SettingsManager::commitSettings() {
 }
 
 void SettingsManager::uncommitSettings() {
-    LockGuard lock(mtx_);
+    LockGuard lock(lock_);
     if (initialized_ == false || dirty_ == false) {
         return;
     }

--- a/src/app/SettingsManager/SettingsManager.hpp
+++ b/src/app/SettingsManager/SettingsManager.hpp
@@ -5,6 +5,7 @@
 #include <HalStorage.hpp>
 #include <config.h>
 #include "SettingsDefs.hpp"
+#include "SettingsLock.hpp"
 
 using namespace SettingsDefs;
 
@@ -15,7 +16,7 @@ public:
     , initialized_(false)
     , dirty_(false)
     {
-        mutex_init(&mtx_);
+        lock_.init();
     }
 
     /**
@@ -101,7 +102,7 @@ public:
      * @return dirty_の値
      */
     bool getIsDirty() const {
-        LockGuard lock(mtx_);
+        LockGuard lock(lock_);
         return dirty_;
     }
 
@@ -123,11 +124,11 @@ private:
 
     bool initialized_;
     bool dirty_;
-    mutable mutex_t mtx_;
+    mutable SettingsLock lock_;
     struct LockGuard {
-        mutex_t& m;
-        LockGuard(mutex_t& m_) : m(m_) { mutex_enter_blocking(&m); }
-        ~LockGuard() { mutex_exit(&m); }
+        SettingsLock& lock;
+        LockGuard(SettingsLock& lock_) : lock(lock_) { lock.lock(); }
+        ~LockGuard() { lock.unlock(); }
     };
 
 };

--- a/test/ci/test_settings_manager/test_main.cpp
+++ b/test/ci/test_settings_manager/test_main.cpp
@@ -1,0 +1,75 @@
+#include <unity.h>
+#include <SettingsManager/SettingsManager.hpp>
+#include <StorageMock.hpp>
+
+static void test_begin_loads_defaults_when_storage_is_empty() {
+    StorageMock storage;
+    SettingsManager manager(storage);
+
+    TEST_ASSERT_TRUE(manager.begin());
+    TEST_ASSERT_TRUE(storage.begin_called);
+    TEST_ASSERT_EQUAL(sizeof(Settings), storage.begin_size);
+
+    const Settings& settings = manager.getAllSettings();
+    TEST_ASSERT_EQUAL_UINT8(1, settings.version);
+    TEST_ASSERT_FALSE(manager.getIsDirty());
+
+    for (size_t i = 0; i < MAX_PEDALS; ++i) {
+        const PedalSettings& pedal = manager.getPedalSettings(i);
+        TEST_ASSERT_EQUAL(static_cast<int>(PedalMode::CC), static_cast<int>(pedal.pedalMode));
+        TEST_ASSERT_EQUAL_UINT8(1, pedal.midiChannel);
+        TEST_ASSERT_EQUAL_UINT8(i + 1, pedal.ccNumber);
+        TEST_ASSERT_EQUAL(static_cast<int>(SwitchBehavior::MOMENTARY), static_cast<int>(pedal.switchBehavior));
+    }
+
+    TEST_ASSERT_GREATER_OR_EQUAL(1, storage.commit_called_count);
+}
+
+static void test_setters_mark_dirty_and_commit_clears_dirty() {
+    StorageMock storage;
+    SettingsManager manager(storage);
+    TEST_ASSERT_TRUE(manager.begin());
+
+    manager.setMidiChannel(0, 3);
+    manager.setCCNumber(0, 74);
+    manager.setSwitchBehavior(0, SwitchBehavior::TOGGLE);
+    manager.setPedalMode(0, PedalMode::PC_NEXT);
+
+    TEST_ASSERT_TRUE(manager.getIsDirty());
+    TEST_ASSERT_EQUAL_UINT8(3, manager.getPedalSettings(0).midiChannel);
+    TEST_ASSERT_EQUAL_UINT8(74, manager.getPedalSettings(0).ccNumber);
+    TEST_ASSERT_EQUAL(static_cast<int>(SwitchBehavior::TOGGLE), static_cast<int>(manager.getPedalSettings(0).switchBehavior));
+    TEST_ASSERT_EQUAL(static_cast<int>(PedalMode::PC_NEXT), static_cast<int>(manager.getPedalSettings(0).pedalMode));
+
+    TEST_ASSERT_TRUE(manager.commitSettings());
+    TEST_ASSERT_FALSE(manager.getIsDirty());
+}
+
+static void test_uncommit_restores_persisted_settings() {
+    StorageMock storage;
+    SettingsManager manager(storage);
+    TEST_ASSERT_TRUE(manager.begin());
+
+    manager.setMidiChannel(0, 7);
+    TEST_ASSERT_TRUE(manager.commitSettings());
+    TEST_ASSERT_EQUAL_UINT8(7, manager.getPedalSettings(0).midiChannel);
+
+    manager.setMidiChannel(0, 11);
+    TEST_ASSERT_TRUE(manager.getIsDirty());
+    TEST_ASSERT_EQUAL_UINT8(11, manager.getPedalSettings(0).midiChannel);
+
+    manager.uncommitSettings();
+    TEST_ASSERT_FALSE(manager.getIsDirty());
+    TEST_ASSERT_EQUAL_UINT8(7, manager.getPedalSettings(0).midiChannel);
+}
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    UNITY_BEGIN();
+    RUN_TEST(test_begin_loads_defaults_when_storage_is_empty);
+    RUN_TEST(test_setters_mark_dirty_and_commit_clears_dirty);
+    RUN_TEST(test_uncommit_restores_persisted_settings);
+    return UNITY_END();
+}

--- a/test/unity_config.cpp
+++ b/test/unity_config.cpp
@@ -1,4 +1,5 @@
 // test/unity_config.cpp
+#ifndef PIPEDAL_NATIVE_TEST
 #include <Arduino.h>
 
 extern "C" {
@@ -22,3 +23,4 @@ void unityOutputComplete(void) {
 }
 
 } // extern "C"
+#endif


### PR DESCRIPTION
## 概要
SettingsManager / Storage 周辺の実機依存を分離し、native 環境で設定ロジックを検証できるようにします。

## スコープ
- `HalStorage` から `Arduino.h` 依存を除去
- SettingsManager の mutex 依存を `SettingsLock` に分離
- native テストでは `SettingsLock` を no-op にして PC 上でコンパイル可能化
- `env:native` で SettingsManager 実装をビルド対象に追加
- `test/ci/test_settings_manager` を追加

## Issue
Closes #65

## 確認内容
- `pio test -e native`
- `pio test -e native --list-tests`
- `pio run -e pico`
- `pio run -e pico-debug`

## 補足
この PR は #77 を前提にした stacked PR です。#76/#77 が merge された後に `develop` 向けへ retarget する想定です。
