### PR TITLE
refactor: 設定依存をSettingsStoreへ分離 #71

### DIFF
--- a/src/app/MenuController/MenuController.hpp
+++ b/src/app/MenuController/MenuController.hpp
@@ -5,14 +5,14 @@
 #include <MenuManager/MenuState.hpp>
 #include <HalRotaryEncoder.hpp>
 #include <HalDisplay.hpp>
-#include <SettingsManager/SettingsManager.hpp>
+#include <SettingsManager/SettingsStore.hpp>
 
 using namespace MenuState;
 
 class MenuController {
 public:
-    MenuController(HalDisplay& display, HalRotaryEncoder& rotaryEncoder, SettingsManager& settingsManager)
-        : rotaryEncoder_(rotaryEncoder),  menuManager_(settingsManager, display){
+    MenuController(HalDisplay& display, HalRotaryEncoder& rotaryEncoder, SettingsStore& settingsStore)
+        : rotaryEncoder_(rotaryEncoder),  menuManager_(settingsStore, display){
         self = this;
     }
     ~MenuController() = default;

--- a/src/app/MenuManager/MenuManager.cpp
+++ b/src/app/MenuManager/MenuManager.cpp
@@ -43,7 +43,7 @@ void MenuManager::enterSelectedItem() {
         case MenuType::FUNCTION: {
             // 関数を呼び出す
             if(currentMenu.menuID == MenuID::SETTINGS && index) {
-                settingsManager_.FactoryReset();
+                settingsStore_.FactoryReset();
             }
         }
         case MenuType::APPLY: {
@@ -52,7 +52,7 @@ void MenuManager::enterSelectedItem() {
             break;
         }
         case MenuType::SAVE: {
-            settingsManager_.commitSettings();
+            settingsStore_.commitSettings();
             // 保存処理（必要に応じて実装）
             break;
         }
@@ -136,15 +136,15 @@ void MenuManager::applySettings() {
     switch (currentMenu.menuID)
     {
     case MenuID::PEDAL_ASSIGNMENT:
-        settingsManager_.setPedalMode(param-1, static_cast<PedalMode>(getParamValue(ParamID::PARAM_PEDAL_MIDI_MODE)));
-        settingsManager_.setMidiChannel(param-1, getParamValue(ParamID::PARAM_PEDAL_MIDI_CHANNEL));
-        settingsManager_.setCCNumber(param-1, getParamValue(ParamID::PARAM_PEDAL_CC_NUMBER));
-        settingsManager_.setSwitchBehavior(param-1, static_cast<SwitchBehavior>(getParamValue(ParamID::PARAM_PEDAL_SWITCH_MODE)));
+        settingsStore_.setPedalMode(param-1, static_cast<PedalMode>(getParamValue(ParamID::PARAM_PEDAL_MIDI_MODE)));
+        settingsStore_.setMidiChannel(param-1, getParamValue(ParamID::PARAM_PEDAL_MIDI_CHANNEL));
+        settingsStore_.setCCNumber(param-1, getParamValue(ParamID::PARAM_PEDAL_CC_NUMBER));
+        settingsStore_.setSwitchBehavior(param-1, static_cast<SwitchBehavior>(getParamValue(ParamID::PARAM_PEDAL_SWITCH_MODE)));
         break;
     
     case MenuID::EXP_PEDAL_ASSIGNMENT:
-        settingsManager_.setMidiChannel(PEDAL_COUNT, getParamValue(ParamID::PARAM_EXP_PEDAL_MIDI_CHANNEL));
-        settingsManager_.setCCNumber(PEDAL_COUNT, getParamValue(ParamID::PARAM_EXP_PEDAL_CC_NUMBER));
+        settingsStore_.setMidiChannel(PEDAL_COUNT, getParamValue(ParamID::PARAM_EXP_PEDAL_MIDI_CHANNEL));
+        settingsStore_.setCCNumber(PEDAL_COUNT, getParamValue(ParamID::PARAM_EXP_PEDAL_CC_NUMBER));
         break;
     
     default:
@@ -156,16 +156,16 @@ void MenuManager::MemToParam() {
     switch (currentMenu.menuID)
     {
     case MenuID::PEDAL_ASSIGNMENT:
-        setParamValue(ParamID::PARAM_PEDAL_MIDI_MODE, static_cast<int>(settingsManager_.getPedalSettings(param-1).pedalMode));
-        setParamValue(ParamID::PARAM_PEDAL_MIDI_CHANNEL, settingsManager_.getPedalSettings(param-1).midiChannel);
-        setParamValue(ParamID::PARAM_PEDAL_CC_NUMBER, settingsManager_.getPedalSettings(param-1).ccNumber);
-        setParamValue(ParamID::PARAM_PEDAL_SWITCH_MODE, static_cast<int>(settingsManager_.getPedalSettings(param-1).switchBehavior));
+        setParamValue(ParamID::PARAM_PEDAL_MIDI_MODE, static_cast<int>(settingsStore_.getPedalSettings(param-1).pedalMode));
+        setParamValue(ParamID::PARAM_PEDAL_MIDI_CHANNEL, settingsStore_.getPedalSettings(param-1).midiChannel);
+        setParamValue(ParamID::PARAM_PEDAL_CC_NUMBER, settingsStore_.getPedalSettings(param-1).ccNumber);
+        setParamValue(ParamID::PARAM_PEDAL_SWITCH_MODE, static_cast<int>(settingsStore_.getPedalSettings(param-1).switchBehavior));
         
         break;
     
     case MenuID::EXP_PEDAL_ASSIGNMENT:
-        setParamValue(ParamID::PARAM_EXP_PEDAL_MIDI_CHANNEL, settingsManager_.getPedalSettings(PEDAL_COUNT).midiChannel);
-        setParamValue(ParamID::PARAM_EXP_PEDAL_CC_NUMBER, settingsManager_.getPedalSettings(PEDAL_COUNT).ccNumber);
+        setParamValue(ParamID::PARAM_EXP_PEDAL_MIDI_CHANNEL, settingsStore_.getPedalSettings(PEDAL_COUNT).midiChannel);
+        setParamValue(ParamID::PARAM_EXP_PEDAL_CC_NUMBER, settingsStore_.getPedalSettings(PEDAL_COUNT).ccNumber);
         break;
     
     default:

--- a/src/app/MenuManager/MenuManager.hpp
+++ b/src/app/MenuManager/MenuManager.hpp
@@ -5,16 +5,16 @@
 #include <config.h>
 #include <HalStorage.hpp>
 
-#include <SettingsManager/SettingsManager.hpp>
+#include <SettingsManager/SettingsStore.hpp>
 #include <MenuDisplay/MenuDisplay.hpp>
 
 using namespace MenuState;
 
 class MenuManager {
 public:
-    MenuManager(SettingsManager& settingsManager, HalDisplay& display)
+    MenuManager(SettingsStore& settingsStore, HalDisplay& display)
     : menuDisplay_(display)
-    , settingsManager_(settingsManager)
+    , settingsStore_(settingsStore)
     {}
     ~MenuManager() = default;
 
@@ -56,7 +56,7 @@ private:
 
     void MemToParam();
 
-    SettingsManager& settingsManager_;
+    SettingsStore& settingsStore_;
     MenuDisplay menuDisplay_;
 
     MenuConfig currentMenu;

--- a/src/app/PedalsController/PedalsController.hpp
+++ b/src/app/PedalsController/PedalsController.hpp
@@ -5,7 +5,7 @@
 #include <HalPedal.hpp>
 #include <HalExpPedal.hpp>
 #include <HalUSBMIDI.hpp>
-#include <SettingsManager/SettingsManager.hpp>
+#include <SettingsManager/SettingsStore.hpp>
 #include <SettingsManager/SettingsDefs.hpp>
 #include <config.h>
 
@@ -15,7 +15,7 @@ public:
     PedalsController(HalPedal& pedals,
                      HalExpPedal& expPedal,
                      HalUSBMIDI& usbMIDI,
-                     SettingsManager& settings)
+                     SettingsStore& settings)
     : pedals_(pedals)
     , expPedal_(expPedal)
     , usbMIDI_(usbMIDI)
@@ -56,7 +56,7 @@ private:
     HalPedal&    pedals_;
     HalExpPedal& expPedal_;
     HalUSBMIDI&  usbMIDI_;
-    SettingsManager& settings_;
+    SettingsStore& settings_;
 
     static PedalsController* self;
 

--- a/src/app/SettingsManager/SettingsManager.hpp
+++ b/src/app/SettingsManager/SettingsManager.hpp
@@ -6,10 +6,11 @@
 #include <config.h>
 #include "SettingsDefs.hpp"
 #include "SettingsLock.hpp"
+#include "SettingsStore.hpp"
 
 using namespace SettingsDefs;
 
-class SettingsManager {
+class SettingsManager : public SettingsStore {
 public:
     explicit SettingsManager(HalStorage& storage)
     : storage_(storage)
@@ -31,42 +32,42 @@ public:
      * @brief 全設定取得
      * @return 全設定(Settings)
     */
-    const Settings& getAllSettings() const;
+    const Settings& getAllSettings() const override;
 
     /**
      * @brief 指定ペダルの設定取得
      * @param pedalIndex ペダルインデックス
      * @return ペダル設定(PedalSettings)
     */
-    const PedalSettings& getPedalSettings(size_t pedalIndex) const;
+    const PedalSettings& getPedalSettings(size_t pedalIndex) const override;
 
     /**
      * @brief Setter群 (RAMのみ更新、EEPROMはまだ)
      * @param pedalIndex ペダルインデックス
      * @param mode ペダルモード(PedalMode::CC, PC_NEXT, PC_BACK)
      */
-    void setPedalMode(size_t pedalIndex, PedalMode mode);
+    void setPedalMode(size_t pedalIndex, PedalMode mode) override;
     
     /**
      * @brief MIDIチャンネル設定
      * @param pedalIndex ペダルインデックス
      * @param ch MIDIチャンネル(1-16)
      */
-    void setMidiChannel(size_t pedalIndex, uint8_t ch);
+    void setMidiChannel(size_t pedalIndex, uint8_t ch) override;
 
     /**
      * @brief CC番号設定
      * @param pedalIndex ペダルインデックス
      * @param cc CC番号(0-127)
      */
-    void setCCNumber(size_t pedalIndex, uint8_t cc);
+    void setCCNumber(size_t pedalIndex, uint8_t cc) override;
 
     /**
      * @brief スイッチ動作設定
      * @param pedalIndex ペダルインデックス
      * @param behavior スイッチ動作(SwitchBehavior::MOMENTARY/TOGGLE)
      */
-    void setSwitchBehavior(size_t pedalIndex, SwitchBehavior behavior);
+    void setSwitchBehavior(size_t pedalIndex, SwitchBehavior behavior) override;
 
 
     /**
@@ -74,34 +75,34 @@ public:
      * @param pedalIndex ペダルインデックス
      * @param ps ペダル設定(PedalSettings)
      */
-    void setPedalSettings(size_t pedalIndex, const PedalSettings& ps);
+    void setPedalSettings(size_t pedalIndex, const PedalSettings& ps) override;
 
     /**
      * @brief 全設定一括設定
      * @param s 全設定(Settings)
      */
-    void setAllSettings(const Settings& s);
+    void setAllSettings(const Settings& s) override;
 
     /**
      * @brief RAM→EEPROMへ反映（dirty_のときだけ）
      */
-    bool commitSettings();
+    bool commitSettings() override;
 
     /**
      * @brief dirty_を強制的にfalseにする（EEPROM反映済み扱いにする）
      */
-    void uncommitSettings();
+    void uncommitSettings() override;
 
     /**
      * @brief デフォルト設定をRAM+EEPROMへ反映
      */
-    void FactoryReset();
+    void FactoryReset() override;
 
     /**
      * @brief 設定がEEPROMに反映されていないかどうか取得
      * @return dirty_の値
      */
-    bool getIsDirty() const {
+    bool getIsDirty() const override {
         LockGuard lock(lock_);
         return dirty_;
     }

--- a/src/app/SettingsManager/SettingsStore.hpp
+++ b/src/app/SettingsManager/SettingsStore.hpp
@@ -1,0 +1,29 @@
+#ifndef SETTINGSSTORE_HPP_
+#define SETTINGSSTORE_HPP_
+
+#include <stddef.h>
+#include "SettingsDefs.hpp"
+
+using namespace SettingsDefs;
+
+class SettingsStore {
+public:
+    virtual ~SettingsStore() {}
+
+    virtual const Settings& getAllSettings() const = 0;
+    virtual const PedalSettings& getPedalSettings(size_t pedalIndex) const = 0;
+
+    virtual void setPedalMode(size_t pedalIndex, PedalMode mode) = 0;
+    virtual void setMidiChannel(size_t pedalIndex, uint8_t ch) = 0;
+    virtual void setCCNumber(size_t pedalIndex, uint8_t cc) = 0;
+    virtual void setSwitchBehavior(size_t pedalIndex, SwitchBehavior behavior) = 0;
+    virtual void setPedalSettings(size_t pedalIndex, const PedalSettings& ps) = 0;
+    virtual void setAllSettings(const Settings& s) = 0;
+
+    virtual bool commitSettings() = 0;
+    virtual void uncommitSettings() = 0;
+    virtual void FactoryReset() = 0;
+    virtual bool getIsDirty() const = 0;
+};
+
+#endif // SETTINGSSTORE_HPP_

--- a/test/Mocks/SettingsStoreMock.hpp
+++ b/test/Mocks/SettingsStoreMock.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <SettingsManager/SettingsStore.hpp>
+
+class SettingsStoreMock : public SettingsStore {
+public:
+    SettingsStoreMock()
+        : commitReturnValue(true),
+          commitCalledCount(0),
+          factoryResetCalled(false),
+          uncommitCalled(false),
+          dirty(false)
+    {
+        settings.version = 1;
+        for (size_t i = 0; i < MAX_PEDALS; ++i) {
+            settings.pedal[i].pedalMode = PedalMode::CC;
+            settings.pedal[i].midiChannel = 1;
+            settings.pedal[i].ccNumber = i + 1;
+            settings.pedal[i].switchBehavior = SwitchBehavior::MOMENTARY;
+            settings.pedal[i]._pad = 0;
+        }
+    }
+
+    const Settings& getAllSettings() const override {
+        return settings;
+    }
+
+    const PedalSettings& getPedalSettings(size_t pedalIndex) const override {
+        return settings.pedal[pedalIndex];
+    }
+
+    void setPedalMode(size_t pedalIndex, PedalMode mode) override {
+        if (pedalIndex >= MAX_PEDALS) return;
+        settings.pedal[pedalIndex].pedalMode = mode;
+        dirty = true;
+    }
+
+    void setMidiChannel(size_t pedalIndex, uint8_t ch) override {
+        if (pedalIndex >= MAX_PEDALS) return;
+        settings.pedal[pedalIndex].midiChannel = ch;
+        dirty = true;
+    }
+
+    void setCCNumber(size_t pedalIndex, uint8_t cc) override {
+        if (pedalIndex >= MAX_PEDALS) return;
+        settings.pedal[pedalIndex].ccNumber = cc;
+        dirty = true;
+    }
+
+    void setSwitchBehavior(size_t pedalIndex, SwitchBehavior behavior) override {
+        if (pedalIndex >= MAX_PEDALS) return;
+        settings.pedal[pedalIndex].switchBehavior = behavior;
+        dirty = true;
+    }
+
+    void setPedalSettings(size_t pedalIndex, const PedalSettings& ps) override {
+        if (pedalIndex >= MAX_PEDALS) return;
+        settings.pedal[pedalIndex] = ps;
+        dirty = true;
+    }
+
+    void setAllSettings(const Settings& s) override {
+        settings = s;
+        dirty = true;
+    }
+
+    bool commitSettings() override {
+        commitCalledCount++;
+        if (commitReturnValue) {
+            dirty = false;
+        }
+        return commitReturnValue;
+    }
+
+    void uncommitSettings() override {
+        uncommitCalled = true;
+        dirty = false;
+    }
+
+    void FactoryReset() override {
+        factoryResetCalled = true;
+        dirty = false;
+    }
+
+    bool getIsDirty() const override {
+        return dirty;
+    }
+
+    Settings settings;
+    bool commitReturnValue;
+    int commitCalledCount;
+    bool factoryResetCalled;
+    bool uncommitCalled;
+    bool dirty;
+};

--- a/test/ci/test_settings_manager/test_main.cpp
+++ b/test/ci/test_settings_manager/test_main.cpp
@@ -1,5 +1,6 @@
 #include <unity.h>
 #include <SettingsManager/SettingsManager.hpp>
+#include <SettingsStoreMock.hpp>
 #include <StorageMock.hpp>
 
 static void test_begin_loads_defaults_when_storage_is_empty() {
@@ -63,6 +64,19 @@ static void test_uncommit_restores_persisted_settings() {
     TEST_ASSERT_EQUAL_UINT8(7, manager.getPedalSettings(0).midiChannel);
 }
 
+static void test_settings_store_mock_tracks_dirty_and_commit() {
+    SettingsStoreMock settings;
+
+    TEST_ASSERT_FALSE(settings.getIsDirty());
+    settings.setMidiChannel(0, 12);
+    TEST_ASSERT_TRUE(settings.getIsDirty());
+    TEST_ASSERT_EQUAL_UINT8(12, settings.getPedalSettings(0).midiChannel);
+
+    TEST_ASSERT_TRUE(settings.commitSettings());
+    TEST_ASSERT_FALSE(settings.getIsDirty());
+    TEST_ASSERT_EQUAL(1, settings.commitCalledCount);
+}
+
 int main(int argc, char** argv) {
     (void)argc;
     (void)argv;
@@ -71,5 +85,6 @@ int main(int argc, char** argv) {
     RUN_TEST(test_begin_loads_defaults_when_storage_is_empty);
     RUN_TEST(test_setters_mark_dirty_and_commit_clears_dirty);
     RUN_TEST(test_uncommit_restores_persisted_settings);
+    RUN_TEST(test_settings_store_mock_tracks_dirty_and_commit);
     return UNITY_END();
 }


### PR DESCRIPTION
## 概要
SettingsManager 具象型への依存を `SettingsStore` インターフェースへ分離し、MenuManager / MenuController / PedalsController へ mock 設定ストアを注入できるようにします。

## スコープ
- `SettingsStore` インターフェースを追加
- `SettingsManager` を `SettingsStore` 実装に変更
- `MenuManager` / `MenuController` / `PedalsController` の依存を `SettingsStore&` に変更
- CI テスト用の `SettingsStoreMock` を追加
- native テストで `SettingsStoreMock` の dirty / commit 挙動を確認

## Issue
Closes #71

## 確認内容
- `pio test -e native`
- `pio run -e pico`
- `pio run -e pico-debug`

## 補足
最新 `develop` から `feature-71` を作成しています。実機構成では従来どおり `SettingsManager settings(storage)` を各コントローラへ渡すため、配線と実行時挙動は維持されます。
